### PR TITLE
Fixed markdown at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Installation
 ============
 
 
-You can install meneco by running::
+You can install meneco by running:
 
 	$ pip install --user meneco
 
@@ -12,11 +12,11 @@ The executable scripts can then be found in ~/.local/bin.
 Usage
 =====
 
-Typical usage is::
+Typical usage is:
 	
 	$ meneco.py draftnetwork.sbml repairnetwork.sbml seeds.sbml targets.sbml
 	
-For more options you can ask for help as follows::
+For more options you can ask for help as follows:
 
 	$ meneco --h
 	    usage: meneco.py [-h] [--enumerate] draftnetwork repairnetwork seeds targets
@@ -35,11 +35,14 @@ For more options you can ask for help as follows::
 Samples
 =======
 
-Sample files for the reconstruction of ectocarpus are available here::
-      ectocyc.sbml_ metacyc_16-5.sbml_ seeds.sbml_ targets.sbml_
+Sample files for the reconstruction of ectocarpus are available here:
+      [ectocyc.sbml][ectocyc.sbml], [metacyc_16-5.sbml][metacyc_16-5.sbml], [seeds.sbml][seeds.sbml], and [targets.sbml][targets.sbml].
 
-.. _ectocyc.sbml: http://bioasp.github.io/downloads/samples/ectodata/ectocyc.sbml
-.. _metacyc_16-5.sbml: http://bioasp.github.io/downloads/samples/ectodata/metacyc_16-5.sbml
-.. _seeds.sbml: http://bioasp.github.io/downloads/samples/ectodata/seeds.sbml
-.. _targets.sbml: http://bioasp.github.io/downloads/samples/ectodata/targets.sbml
+[ectocyc.sbml]: http://bioasp.github.io/downloads/samples/ectodata/ectocyc.sbml
+
+[metacyc_16-5.sbml]: http://bioasp.github.io/downloads/samples/ectodata/metacyc_16-5.sbml
+
+[seeds.sbml]: http://bioasp.github.io/downloads/samples/ectodata/seeds.sbml
+
+[targets.sbml]: http://bioasp.github.io/downloads/samples/ectodata/targets.sbml
 


### PR DESCRIPTION
There were some double colons and problems with the links at the bottom of the README.md file. Was it from another flavor of markdown?
(github flavored markdown did not like the syntax)

Nico
