### PR TITLE
Menecheck

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Installation 
+Installation
 ============
 
 
@@ -15,23 +15,27 @@ Usage
 =====
 
 Typical usage is::
-	
-	$ meneco.py draftnetwork.sbml repairnetwork.sbml seeds.sbml targets.sbml
-	
+
+	$ meneco.py -d draftnetwork.sbml -r repairnetwork.sbml -s seeds.sbml -t targets.sbml
+
 For more options you can ask for help as follows::
 
 	$ meneco.py --h
-	    usage: meneco.py [-h] [--enumerate] draftnetwork repairnetwork seeds targets
-	
-	    positional arguments:
-	      draftnetwork   metabolic network in SBML format
-	      repairnetwork  metabolic network in SBML format
-	      seeds          seeds in SBML format
-	      targets        targets in SBML format
-	
-	    optional arguments:
-	      -h, --help     show this help message and exit
-	      --enumerate    enumerate all minimal completions
+	usage: meneco.py [-h] -d DRAFTNET [-r REPAIRNET] -s SEEDS -t TARGETS
+			 [--enumerate] [--menecheck]
+
+	optional arguments:
+	-h, --help            show this help message and exit
+	-d DRAFTNET, --draftnet DRAFTNET
+						metabolic network in SBML format
+	-r REPAIRNET, --repairnet REPAIRNET
+						metabolic network in SBML format
+	-s SEEDS, --seeds SEEDS
+						seeds in SBML format
+	-t TARGETS, --targets TARGETS
+						targets in SBML format
+	--enumerate           enumerate all minimal completions
+	--menecheck           test only the producibility of the targets
 
 
 Samples
@@ -43,4 +47,3 @@ Sample files for the reconstruction of ectocarpus are available here: ectocyc.sb
 .. _metacyc_16-5.sbml: http://bioasp.github.io/downloads/samples/ectodata/metacyc_16-5.sbml
 .. _seeds.sbml: http://bioasp.github.io/downloads/samples/ectodata/seeds.sbml
 .. _targets.sbml: http://bioasp.github.io/downloads/samples/ectodata/targets.sbml
-

--- a/meneco.py
+++ b/meneco.py
@@ -25,25 +25,35 @@ if __name__ == '__main__':
 
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("draftnetwork",
+
+    parser.add_argument("-d", "--draftnet",
+                        help="metabolic network in SBML format", required=True)
+    parser.add_argument("-r", "--repairnet",
                         help="metabolic network in SBML format")
-    parser.add_argument("repairnetwork",
-                        help="metabolic network in SBML format")
-    parser.add_argument("seeds",
-                        help="seeds in SBML format")
-    parser.add_argument("targets",
-                        help="targets in SBML format")
+    parser.add_argument("-s", "--seeds",
+                        help="seeds in SBML format", required=True)
+    parser.add_argument("-t", "--targets",
+                        help="targets in SBML format", required=True)
 
     parser.add_argument('--enumerate',
                         help="enumerate all minimal completions",
                         action="store_true")
 
+    parser.add_argument('--menecheck',
+                        help="test only the producibility of the targets",
+                        action="store_true")
+
     args = parser.parse_args()
 
-    draft_sbml = args.draftnetwork
-    repair_sbml = args.repairnetwork
+    draft_sbml = args.draftnet
+    repair_sbml = args.repairnet
     seeds_sbml = args.seeds
     targets_sbml =  args.targets
+
+    if not args.menecheck and not repair_sbml:
+        parser.print_help()
+        print('\nREPAIRNET is required to run meneco without --menecheck')
+        quit()
 
     print('Reading draft network from ',draft_sbml,'...',end=' ')
     sys.stdout.flush()
@@ -74,6 +84,9 @@ if __name__ == '__main__':
       target= str(a)[13:]
       t = String2TermSet(target)
       unproducible_targets = TermSet(unproducible_targets.union(t))
+
+    if args.menecheck:
+        quit()
 
     print('\nReading repair network from ',repair_sbml,'...',end=' ')
     sys.stdout.flush()
@@ -161,4 +174,3 @@ if __name__ == '__main__':
         print('Completion '+str(count)+':')
         count+=1
         utils.print_met(model.to_list())
-


### PR DESCRIPTION
menecheck (or whatever other name) is an option to meneco (-- menecheck so far). It needs a draft network, seeds and targets and topologically checks the producibility of the targets. Thus it is not necessary to give the repair network as an input. To allow this, I had to reshape the way meneco is called : meneco.py -d draft.sbml -r repairnet.sbml -s seeds.sbml -t targets.sbml 